### PR TITLE
Added a repo that has been excluded from HacktoberFest 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 - [Hacktoberfest2023(fineanmol)](https://github.com/fineanmol/Hacktoberfest2023)
 - [Hacktoberfest2023(Midway91)](https://github.com/Midway91/HactoberFest2023)
 - [PreciousServices(SyedImtiyaz-1)](https://github.com/SyedImtiyaz-1/PreciousServices)
+- [Swags-for-Developers](https://github.com/MrKrishnaAgarwal/Swags-for-Developers)
 - [Web-Dev-Project-for-Hacktoberfest2023(surajsharma14)](https://github.com/surajsharma14/Web-Dev-Project-for-Hacktoberfest2023)
 - [Btecky(laviii123)](https://github.com/laviii123/Btecky)
 


### PR DESCRIPTION
I contributed to this repo some days back but got to know that this repo has been excluded.

## Contributing

If you want to add a project to this list, please make sure that:

- [x] You read the [contributing guide](https://github.com/OtacilioN/awesome-hacktoberfest-2020/blob/master/CONTRIBUTING.md)
- [x] The repository has hacktoberfest as topic and counts for hacktoberfest event
- [x] The project can't be just an "add your name" or simply + 1 contribution to hacktoberfest
- [x] Place them in alphabetical order
- [x] One repository per PR/contribution - _avoid conflicts and simplify review_
- [x] Your pull request is not spammy just adding an empty line, otherwise it will be marked as invalid and not count to hacktoberfest.

If they meet the requirements above, feel free to create a PR. Happy Hacking! :sparkles: 
